### PR TITLE
In MailgunSender use the domain from the fromEmail

### DIFF
--- a/src/Email/Service/MailgunSender.php
+++ b/src/Email/Service/MailgunSender.php
@@ -72,8 +72,13 @@ class MailgunSender implements SenderInterface, ContainerAwareInterface
             $message['bcc'] = $this->convertEmailsArrayToString($bcc);
         }
 
+        if (!preg_match('/@(.+)$/', $fromEmail, $matches)) {
+            throw new \Exception("Invalid from address: {$fromEmail}");
+        }
+        $domain = $matches[1];
+
         $this->container['mailgun']->sendMessage(
-            $this->container['config']['email']['mailgun_domain'],
+            $domain,
             $message
         );
     }


### PR DESCRIPTION
I don't know why Mailgun doesn't just do this anyway!

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apitude/apitude/18)

<!-- Reviewable:end -->
