### PR TITLE
Automatically inline css when calling Mailgun sendTemplate

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
     "dotblue/mandrill": "^1",
     "xamin/handlebars.php": "^0.10",
     "mailgun/mailgun-php": "^2.0",
-    "php-http/guzzle6-adapter": "^1.0"
+    "php-http/guzzle6-adapter": "^1.0",
+    "tijsverkoyen/css-to-inline-styles": "^2.0@dev"
   },
   "require-dev": {
     "phpunit/phpunit": "~4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "c20ac682bf8b22c447e56a56a6cef093",
-    "content-hash": "c57bd6d4121185e3136e1240e7a9d460",
+    "hash": "3e79a7eb0e76b8057d69db7e16e991f1",
+    "content-hash": "ca49d27ff7f14d51c2ee5110ef56a56b",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2020,6 +2020,59 @@
             "time": "2016-03-17 09:19:04"
         },
         {
+            "name": "symfony/css-selector",
+            "version": "v3.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/css-selector.git",
+                "reference": "65e764f404685f2dc20c057e889b3ad04b2e2db0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/65e764f404685f2dc20c057e889b3ad04b2e2db0",
+                "reference": "65e764f404685f2dc20c057e889b3ad04b2e2db0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\CssSelector\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jean-François Simon",
+                    "email": "jeanfrancois.simon@sensiolabs.com"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony CssSelector Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-03-04 07:55:57"
+        },
+        {
             "name": "symfony/debug",
             "version": "v2.8.4",
             "source": {
@@ -2569,6 +2622,52 @@
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
             "time": "2016-03-04 07:54:35"
+        },
+        {
+            "name": "tijsverkoyen/css-to-inline-styles",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/tijsverkoyen/CssToInlineStyles.git",
+                "reference": "bb535b05ba1e23a0400ecc73adaa00d37289baf1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/tijsverkoyen/CssToInlineStyles/zipball/bb535b05ba1e23a0400ecc73adaa00d37289baf1",
+                "reference": "bb535b05ba1e23a0400ecc73adaa00d37289baf1",
+                "shasum": ""
+            },
+            "require": {
+                "symfony/css-selector": "^2.7|~3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8|5.1.*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "TijsVerkoyen\\CssToInlineStyles\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Tijs Verkoyen",
+                    "email": "css_to_inline_styles@verkoyen.eu",
+                    "role": "Developer"
+                }
+            ],
+            "description": "CssToInlineStyles is a class that enables you to convert HTML-pages/files into HTML-pages/files with inline styles. This is very useful when you're sending emails.",
+            "homepage": "https://github.com/tijsverkoyen/CssToInlineStyles",
+            "time": "2016-02-23 13:27:47"
         },
         {
             "name": "xamin/handlebars.php",
@@ -3645,59 +3744,6 @@
             "time": "2016-03-04 07:55:57"
         },
         {
-            "name": "symfony/css-selector",
-            "version": "v3.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/css-selector.git",
-                "reference": "65e764f404685f2dc20c057e889b3ad04b2e2db0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/65e764f404685f2dc20c057e889b3ad04b2e2db0",
-                "reference": "65e764f404685f2dc20c057e889b3ad04b2e2db0",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5.9"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\CssSelector\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jean-François Simon",
-                    "email": "jeanfrancois.simon@sensiolabs.com"
-                },
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony CssSelector Component",
-            "homepage": "https://symfony.com",
-            "time": "2016-03-04 07:55:57"
-        },
-        {
             "name": "symfony/dom-crawler",
             "version": "v3.0.4",
             "source": {
@@ -3942,7 +3988,8 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "monolog/monolog": 20
+        "monolog/monolog": 20,
+        "tijsverkoyen/css-to-inline-styles": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/src/Email/Service/MailgunSender.php
+++ b/src/Email/Service/MailgunSender.php
@@ -33,20 +33,17 @@ class MailgunSender implements SenderInterface, ContainerAwareInterface
      * @param array  $parameters
      * @param array  $cc
      * @param array  $bcc
-     * @param bool   $inlineCss
      * @return mixed
      * @throws \Exception
      */
-    function sendTemplate(array $to, $fromEmail, $fromName, $subject, $template, $parameters = [], $cc = [], $bcc = [], $inlineCss = true)
+    function sendTemplate(array $to, $fromEmail, $fromName, $subject, $template, $parameters = [], $cc = [], $bcc = [])
     {
         $html = $this->container['handlebars']->render(
             $template,
             $parameters
         );
 
-        if ($inlineCss) {
-            $html = (new CssToInlineStyles())->convert($html);
-        }
+        $html = (new CssToInlineStyles())->convert($html);
 
         return $this->send($to, $fromEmail, $fromName, $subject, $html, 'text/html', $cc, $bcc);
     }

--- a/src/Email/Service/MailgunSender.php
+++ b/src/Email/Service/MailgunSender.php
@@ -3,6 +3,7 @@ namespace Apitude\Core\Email\Service;
 
 use Apitude\Core\Provider\ContainerAwareInterface;
 use Apitude\Core\Provider\ContainerAwareTrait;
+use TijsVerkoyen\CssToInlineStyles\CssToInlineStyles;
 
 class MailgunSender implements SenderInterface, ContainerAwareInterface
 {
@@ -24,44 +25,51 @@ class MailgunSender implements SenderInterface, ContainerAwareInterface
     }
 
     /**
-     * @param array $to
+     * @param array  $to
      * @param string $fromEmail
      * @param string $fromName
      * @param string $subject
      * @param string $template
-     * @param array $parameters
-     * @param array $cc
-     * @param array $bcc
+     * @param array  $parameters
+     * @param array  $cc
+     * @param array  $bcc
+     * @param bool   $inlineCss
      * @return mixed
+     * @throws \Exception
      */
-    function sendTemplate(array $to, $fromEmail, $fromName, $subject, $template, $parameters = [], $cc = [], $bcc = [])
+    function sendTemplate(array $to, $fromEmail, $fromName, $subject, $template, $parameters = [], $cc = [], $bcc = [], $inlineCss = true)
     {
         $html = $this->container['handlebars']->render(
             $template,
             $parameters
         );
 
+        if ($inlineCss) {
+            $html = (new CssToInlineStyles())->convert($html);
+        }
+
         return $this->send($to, $fromEmail, $fromName, $subject, $html, 'text/html', $cc, $bcc);
     }
 
     /**
-     * @param array $to
+     * @param array  $to
      * @param string $fromEmail
      * @param string $fromName
      * @param string $subject
      * @param string $body
      * @param string $contentType
-     * @param array $cc
-     * @param array $bcc
+     * @param array  $cc
+     * @param array  $bcc
      * @return mixed
+     * @throws \Exception
      */
     function send(array $to, $fromEmail, $fromName, $subject, $body, $contentType = 'text/html', $cc = [], $bcc = [])
     {
         $message = [
-            'to' => $this->convertEmailsArrayToString($to),
-            'from' => "{$fromName} <{$fromEmail}>",
+            'to'      => $this->convertEmailsArrayToString($to),
+            'from'    => "{$fromName} <{$fromEmail}>",
             'subject' => $subject,
-            'html' => $body,
+            'html'    => $body,
         ];
 
         if ($cc) {


### PR DESCRIPTION
Mailgun doesn't handle inlining css automatically through their API, so let's add the ability to do it here.

<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apitude/apitude/20)

<!-- Reviewable:end -->
